### PR TITLE
chore: add example of shellHook in flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -39,6 +39,11 @@
       {
         devShells.default = pkgs.mkShell {
           inherit buildInputs nativeBuildInputs;
+          # example of shellHook
+          # shellHook = ''
+          #   export PATH=$PATH:''${CARGO_HOME:-~/.cargo}/bin
+          #   cargo install cargo-snippet --features="binaries"
+          # '';
         };
       }
     );

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,4 @@
-reorder_modules = false
-use_small_heuristics = "Max"
+edition                  = "2021"
+use_field_init_shorthand = true
+use_small_heuristics     = "Max"
+use_try_shorthand        = true


### PR DESCRIPTION
also add some rustfmt options

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added a `shellHook` example to guide users in setting up environment variables and installing the Cargo package, enhancing the customization of their development environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->