### PR TITLE
(chore): use nightly fmt, workaround for RA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ result
 !.vscode/launch.json
 !.vscode/extensions.json
 !.vscode/*.code-snippets
+!.vscode/settings.json
 
 # Local History for Visual Studio Code
 .history/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "rust-analyzer.cargo.extraEnv": {
+        "RUSTUP_TOOLCHAIN": "stable"
+    },
+    "rust-analyzer.rustfmt.extraArgs": [
+        "+nightly"
+    ],
+}

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,10 +1,49 @@
-edition                  = "2021"
-reorder_imports          = true
+# it seems 2021 edition on coderun side
+edition = "2021"
+# Let's be consistent
+newline_style = "Unix"
+# require the shorthand instead of it being optional
 use_field_init_shorthand = true
-use_small_heuristics     = "Max"
-use_try_shorthand        = true
+# Max to use the 100 char width for everything or Default. See https://rust-lang.github.io/rustfmt/?version=v1.4.38&search=#use_small_heuristics
+use_small_heuristics = "Max"
+# outdated default — `?` was unstable at the time
+# additionally the `try!` macro is deprecated now
+use_try_shorthand = true
 
-# let's wait mythical rustfmt 2.0
-#unstable_features   = true
-#group_imports       = "StdExternalCrate"
-#imports_granularity = "Crate"
+# review this group later
+reorder_imports               = true
+struct_lit_width              = 100
+single_line_if_else_max_width = 100
+max_width                     = 100
+array_width                   = 100
+attr_fn_like_width            = 100
+fn_call_width                 = 100
+match_block_trailing_comma    = true
+
+# Unstable features below
+unstable_features = true
+style_edition     = "2024"
+# code can be 100 characters, why not comments?
+comment_width = 100
+# force contributors to follow the formatting requirement
+error_on_line_overflow = true
+error_on_unformatted   = true
+# next 4: why not?
+format_code_in_doc_comments = true
+format_macro_bodies         = true
+format_macro_matchers       = true
+format_strings              = true
+# better grepping
+imports_granularity = "Module"
+# quicker manual lookup
+group_imports = "StdExternalCrate"
+# why use an attribute if a normal doc comment would suffice?
+normalize_doc_attributes = true
+# why not?
+wrap_comments = true
+
+# review this group later
+fn_single_line          = true
+overflow_delimited_expr = true
+reorder_impl_items      = true
+where_single_line       = true


### PR DESCRIPTION
- **Chores**
	- Adjusted repository configuration to enable sharing of local development preferences, promoting consistency across environments.
	- new version of rust-analyzer refuses to work with tollchain < 1.82, so there is workaround for VSCode
	- nightly options in rustfmt.toml require nightly version of rustfmt