### PR TITLE
refactor(344): change enum Field to enum Checker and update logic

### DIFF
--- a/first_2023_backend/344-checkers/src/main.rs
+++ b/first_2023_backend/344-checkers/src/main.rs
@@ -1,86 +1,76 @@
-use std::{
-    collections::HashMap,
-    convert::Infallible,
-    io::{self, BufRead},
-    iter,
-    str::FromStr,
-};
+use std::collections::HashMap;
+use std::io::{self, BufRead};
+use std::iter;
+use std::str::FromStr;
 
-#[derive(Eq, PartialEq, Hash, Debug, Default, Clone)]
-enum Field {
-    #[default]
-    Empty,
+#[derive(Eq, PartialEq, Hash, Copy, Clone)]
+enum Checker {
     Black,
     White,
 }
 
-impl Field {
-    /// Returns `true` if the field is [`Empty`].
-    ///
-    /// [`Empty`]: Field::Empty
-    #[must_use]
-    const fn is_empty(&self) -> bool {
-        matches!(self, &Self::Empty)
-    }
-}
+impl FromStr for Checker {
+    type Err = &'static str;
 
-impl FromStr for Field {
-    type Err = Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "black" => Ok(Self::Black),
             "white" => Ok(Self::White),
-            _ => Ok(Self::default()), // Orly
+            _ => Err("input is malformed!"),
         }
     }
 }
 
 fn main() {
-    let mut lines = io::stdin().lock().lines().map_while(Result::ok);
+    let must_be_inverse = [(-1, -1), (1, 1), (-1, 1), (1, -1)];
+    let must_be_empty = [(-2, -2), (2, 2), (-2, 2), (2, -2)];
 
-    let mut checkers: HashMap<(isize, isize), Field> = HashMap::new();
-    let must_be_inverse: Vec<(isize, isize)> = vec![(-1, -1), (1, 1), (-1, 1), (1, -1)];
-    let must_be_empty: Vec<(isize, isize)> = vec![(-2, -2), (2, 2), (-2, 2), (2, -2)];
+    let (n, m, checkers, turn) = {
+        let mut lines = io::stdin().lock().lines().map_while(Result::ok);
 
-    let nm = lines.next().unwrap().split_whitespace().flat_map(str::parse).collect::<Vec<_>>();
-    let num_whites = lines.next().unwrap().parse().unwrap();
-    let whites = lines.by_ref().take(num_whites).map(|s| {
-        let mut inner = s.split_ascii_whitespace().flat_map(str::parse);
-        (inner.next().unwrap(), inner.next().unwrap())
-    });
-    checkers.extend(whites.zip(iter::repeat(Field::White)));
-    let num_blacks = lines.next().unwrap().parse().unwrap();
-    let blacks = lines.by_ref().take(num_blacks).map(|s| {
-        let mut inner = s.split_ascii_whitespace().flat_map(str::parse);
-        (inner.next().unwrap(), inner.next().unwrap())
-    });
-    checkers.extend(blacks.zip(iter::repeat(Field::Black)));
-    let turn = lines.next().unwrap().parse().unwrap();
-    drop(lines);
+        let (n, m) = lines
+            .by_ref()
+            .map(|s| {
+                let mut nm = s.split_ascii_whitespace().flat_map(str::parse);
+                (nm.next().unwrap(), nm.next().unwrap())
+            })
+            .next()
+            .unwrap();
 
-    let is_valid_coord = |(i, j)| i <= nm[0] && i > 0 && j <= nm[1] && j > 0;
-    let res = checkers
-        .iter()
-        //интересуют только фишки нашего цвета
-        .filter(|&(&(_, _), color)| *color == turn)
-        //выход после первой подошедшей
-        .any(|(&(i, j), _)| {
-            (0..must_be_inverse.len())
-                .map(|pos| {
-                    (
-                        (must_be_empty[pos].0 + i, must_be_empty[pos].1 + j),
-                        (must_be_inverse[pos].0 + i, must_be_inverse[pos].1 + j),
-                    )
-                })
-                .filter(|&(e, inv)| (is_valid_coord(e) && is_valid_coord(inv)))
-                .any(|(e, inv)| match checkers.get(&e) {
-                    Some(field) if (!field.is_empty()) => false,
-                    Some(_) | None => match checkers.get(&inv) {
-                        Some(field) if (*field != turn) => true,
-                        Some(field) if field.is_empty() => false,
-                        _ => false,
-                    },
-                })
+        // hashmap with coordinate and color
+        let mut checkers: HashMap<(i16, i16), Checker> = HashMap::new();
+        let num_whites = lines.next().unwrap().parse().unwrap();
+        let whites = lines.by_ref().take(num_whites).map(|s| {
+            let mut inner = s.split_ascii_whitespace().flat_map(str::parse);
+            (inner.next().unwrap(), inner.next().unwrap())
         });
+        checkers.extend(iter::zip(whites, iter::repeat(Checker::White)));
+        let num_blacks = lines.next().unwrap().parse().unwrap();
+        let blacks = lines.by_ref().take(num_blacks).map(|s| {
+            let mut inner = s.split_ascii_whitespace().flat_map(str::parse);
+            (inner.next().unwrap(), inner.next().unwrap())
+        });
+        checkers.extend(iter::zip(blacks, iter::repeat(Checker::Black)));
+
+        let turn = lines.next().unwrap().parse().unwrap();
+        drop(lines);
+
+        (n, m, checkers, turn)
+    };
+
+    let is_valid_coord = |(i, j)| i <= n && i > 0 && j <= m && j > 0;
+
+    // интересуют только фишки нашего цвета, выход после первой подошедшей
+    let res = checkers.iter().filter_map(|(coord, color)| (*color == turn).then_some(coord)).any(
+        |(i, j)| {
+            iter::zip(must_be_empty, must_be_inverse)
+                .map(|(empty, inv)| ((empty.0 + i, empty.1 + j), (inv.0 + i, inv.1 + j)))
+                .filter(|&(empty, inv)| is_valid_coord(empty) && is_valid_coord(inv))
+                .any(|(empty, inv)| {
+                    !checkers.contains_key(&empty)
+                        && checkers.get(&inv).is_some_and(|color| *color != turn)
+                })
+        },
+    );
     print!("{}", if res { "Yes" } else { "No" });
 }


### PR DESCRIPTION
This pull request introduces a refactor of the enum previously known as `Field`, which has been renamed to `Checker`. The changes aim to simplify the logic.

#### Changes Made:
- Renamed the enum `Field` to `Checker`.
- Updated the associated logic to reflect this change.
- Removed unnecessary storage of empty fields to streamline the code.